### PR TITLE
fix!: be explicit about sync/async behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     ]
   },
   "scripts": {
+    "clean": "aegir clean",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
     "build": "aegir build",
@@ -129,6 +130,6 @@
     "docs": "aegir docs"
   },
   "devDependencies": {
-    "aegir": "^37.7.8"
+    "aegir": "^38.1.8"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
  * It is a function that takes a source and returns a source.
  */
 export interface Transform<A, B = A> {
-  (source: Source<A>): Source<B>
+  (source: A): B
 }
 
 /**
@@ -12,12 +12,18 @@ export interface Transform<A, B = A> {
  * function that takes a source and iterates over it. It optionally returns
  * a value.
  */
-export interface Sink<T, R = Promise<void>> {
-  (source: Source<T>): R
+export interface Sink<Source, R = Promise<void>> {
+  (source: Source): R
 }
 
 /**
  * A "source" is something that can be consumed. It is an iterable object.
+ *
+ * This type is a union of both sync and async sources - it is useful to keep
+ * code concise but declared types should prefer to specify whether they
+ * accept sync or async sources since treating a synchronous source as an
+ * asynchronous one can lead to performance degradation due to artificially
+ * induced asynchronous behaviour.
  */
 export type Source<T> = AsyncIterable<T> | Iterable<T>
 
@@ -27,6 +33,6 @@ export type Source<T> = AsyncIterable<T> | Iterable<T>
  * an object with two properties, sink and source.
  */
 export interface Duplex<TSource, TSink = TSource, RSink = Promise<void>> {
-  source: Source<TSource>
+  source: TSource
   sink: Sink<TSink, RSink>
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export type Source<T> = AsyncIterable<T> | Iterable<T>
  * necessarily connected to the values that can be consumed from it. It is
  * an object with two properties, sink and source.
  */
-export interface Duplex<TSource, TSink = TSource, RSink = Promise<void>> {
+export interface Duplex<TSource = unknown, TSink = TSource, RSink = Promise<void>> {
   source: TSource
   sink: Sink<TSink, RSink>
 }


### PR DESCRIPTION
Crossing async boundaries is not free so allow the `Duplex` type to specify whether it is sync or async.

BREAKING CHANGE: the `TSource` and `TSink` generic arguments to the `Duplex` type now refer to the stream type and not the type of objects yielded by the stream